### PR TITLE
Aura image

### DIFF
--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -1,11 +1,12 @@
 version: '3.8'
 services:
   substrate:
-    image: prosopo/substrate:demo-v1.0.5
+    image: prosopo/substrate:dev-aura-aadbbed50ede27817158c7517f13f6f61c9cf000
     ports:
       - "9615:9615"
       - "9944:9944"
       - "9933:9933"
+      - "30333:30333"
     deploy:
       # replicas: 1
       resources:

--- a/docker/docker-compose.substrate-contracts-node.yml
+++ b/docker/docker-compose.substrate-contracts-node.yml
@@ -1,14 +1,14 @@
 version: '3.4'
 services:
   substrate-node:
-    image: prosopo/substrate-node:dev
+    image: prosopo/substrate-contracts-node:dev
     build:
       context: .
-      dockerfile: ./images/substrate-node.build.dockerfile
+      dockerfile: ./images/substrate-contracts-node.build.dockerfile
     ports:
       - "9615:9615"
       - "9944:9944"
       - "9933:9933"
       - "30333:30333"
-#    volumes:
-#      - ./chain-data:/chain-data
+    volumes:
+      - ./chain-data:/chain-data

--- a/docker/images/substrate-contracts-node.build.dockerfile
+++ b/docker/images/substrate-contracts-node.build.dockerfile
@@ -1,0 +1,24 @@
+FROM docker.io/paritytech/ci-linux:production AS builder
+
+RUN git clone --depth 1 https://github.com/prosopo-io/substrate-contracts-node
+
+WORKDIR /builds/substrate-contracts-node
+
+RUN cargo build --verbose --locked --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get upgrade -y --only-upgrade libstdc++6
+
+RUN apt-get install -y procps
+
+RUN rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /builds/substrate-contracts-node/target/release/substrate-contracts-node /usr/local/bin
+
+EXPOSE 30333 9933 9944 9615
+
+USER root
+
+CMD exec /bin/bash -c "substrate-contracts-node --dev -d ./chain-data --unsafe-ws-external --rpc-external --prometheus-external -lerror,runtime::contracts=debug"

--- a/docker/images/substrate-contracts-node.dev.dockerfile
+++ b/docker/images/substrate-contracts-node.dev.dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stable-slim
+
+RUN apt-get update && apt install -y curl protobuf-compiler
+
+RUN curl -sL https://github.com/paritytech/substrate-contracts-node/releases/download/v0.24.0/substrate-contracts-node-linux.tar.gz -o /root/substrate-contracts-node-linux.tar.gz
+
+RUN tar -xvf /root/substrate-contracts-node-linux.tar.gz -C /root
+
+RUN mv /root/artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/bin/
+
+RUN rm /root/substrate-contracts-node-linux.tar.gz && rm -rf /root/artifacts
+
+RUN apt autoremove -y && apt clean -y
+
+EXPOSE 30333 9933 9944 9615
+
+ENTRYPOINT /usr/local/bin/substrate-contracts-node --dev -d ./chain-data --unsafe-ws-external --rpc-external --prometheus-external -lerror,runtime::contracts=debug

--- a/docker/images/substrate-node.build.dockerfile
+++ b/docker/images/substrate-node.build.dockerfile
@@ -1,0 +1,24 @@
+FROM docker.io/paritytech/ci-linux:production AS builder
+
+RUN git clone --depth 1 --branch polkadot-v0.9.40 https://github.com/paritytech/substrate
+
+WORKDIR /builds/substrate
+
+RUN cargo build --verbose --locked --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get upgrade -y --only-upgrade libstdc++6
+
+RUN apt-get install -y procps
+
+RUN rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /builds/substrate/target/release/substrate /usr/local/bin
+
+EXPOSE 30333 9933 9944 9615
+
+USER root
+
+CMD exec /bin/bash -c "substrate --dev -d ./chain-data --unsafe-ws-external --rpc-external --prometheus-external -lerror,runtime::contracts=debug"


### PR DESCRIPTION
Creates a substrate image based on the development node that runs with 6s block times. Substrate contracts node image files are renamed. Images are placed in image folder.

```
├── docker
│   ├── contract.debug-deploy.dockerfile
│   ├── docker-compose.contract.deploy.yml
│   ├── docker-compose.demo.yml
│   ├── docker-compose.development.yml
│   ├── docker-compose.substrate-contracts-node.yml
│   ├── docker-compose.substrate-node.yml
│   ├── docker-compose.test.yml
│   └── images
│       ├── substrate-contracts-node.build.dockerfile
│       ├── substrate-contracts-node.dev.dockerfile
│       └── substrate-node.build.dockerfile

```